### PR TITLE
Update Instructions to run the example.txt

### DIFF
--- a/Instructions to run the example.txt
+++ b/Instructions to run the example.txt
@@ -1,10 +1,19 @@
 There are many ways to run R code. The proposed instructions here are focusing on using a graphical interface
 
-::::::INSTALLING R, R STUDIO, AND THE EXEMPLE ::::::
-1. : Go to the page : https://posit.co/download/rstudio-desktop/ and follow the instructions for your operating system
-2. : Unpack the example files on one of your drives, you should end up with a folder containg two folders : a) "Centralised_inference" and b) "Distributed_inference"
+:::::: INSTALLING R, R STUDIO AND THE REQUIRED PACKAGES ::::::
+1) Go to the page : https://posit.co/download/rstudio-desktop/ and follow the instructions for your operating system
+: The example requires the use of two packages not present in the base installation :
+- KS : https://cran.r-project.org/package=ks https://cran.r-project.org/web/packages/ks/ks.pdf
+- this.path : https://cran.r-project.org/package=this.path https://cran.r-project.org/web/packages/this.path/this.path.pdf
+: R should prompt you to download the packages automatically
+2) If you work in an isolated environment, you might need to download them manually at the adress above and install them for your RStudio instance
+: While describing the process here is out of scope, a web search will yield resources like https://riptutorial.com/r/example/5556/install-package-from-local-source that can be helpful.
 
-::::::EXECUTING THE CENTRALISED CODE::::::
+:::::: INSTALLING THE EXAMPLE ::::::
+1) Unpack the example files on one of your drives
+: You should end up with a folder containg two folders : a) "Centralised_inference" and b) "Distributed_inference"
+
+:::::: EXECUTING THE CENTRALISED CODE ::::::
 *** Make sure R studio is not currently running and close it if it is.
 1) Navigate to the folder "Centralised_inference"
 
@@ -12,7 +21,7 @@ There are many ways to run R code. The proposed instructions here are focusing o
 3) Select all the code and click "run"
 4) The result file ("PoolingOrg_results_centralised_lin_reg.csv") will be created. You can open it to see the results.
 
-::::::EXECUTING THE DISTRIBUTED CODE::::::
+:::::: EXECUTING THE DISTRIBUTED CODE ::::::
 *** Make sure R studio is not currently running and close it if it is.
 1) Navigate to the folder "Distributed_inference"
 

--- a/Instructions to run the example.txt
+++ b/Instructions to run the example.txt
@@ -1,12 +1,16 @@
 There are many ways to run R code. The proposed instructions here are focusing on using a graphical interface
 
-:::::: INSTALLING R, R STUDIO AND THE REQUIRED PACKAGES ::::::
+:::::: INSTALLING R and R STUDIO ::::::
 1) Go to the page : https://posit.co/download/rstudio-desktop/ and follow the instructions for your operating system
+
+:::::: INSTALLING THE REQUIRED PACKAGES ::::::
 : The example requires the use of two packages not present in the base installation :
 - KS : https://cran.r-project.org/package=ks https://cran.r-project.org/web/packages/ks/ks.pdf
 - this.path : https://cran.r-project.org/package=this.path https://cran.r-project.org/web/packages/this.path/this.path.pdf
+
 : R should prompt you to download the packages automatically
-2) If you work in an isolated environment, you might need to download them manually at the adress above and install them for your RStudio instance
+
+1) If you work in an isolated environment, you might need to download them manually at the adress above and install them for your RStudio instance
 : While describing the process here is out of scope, a web search will yield resources like https://riptutorial.com/r/example/5556/install-package-from-local-source that can be helpful.
 
 :::::: INSTALLING THE EXAMPLE ::::::


### PR DESCRIPTION
Added the references in the instructions to highlight required packages if the example is run in an isolated environment and the packages can't be downloaded automatically.

(Thanks to C. Burchill for the help).