### PR TITLE
Cox regression: Fixed how string tables are handled

### DIFF
--- a/cox_regression/Cox_model/examples/breast_data/distributed/Coord_node/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data/distributed/Coord_node/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/breast_data/distributed/Coord_node/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data/distributed/Coord_node/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/breast_data/distributed/Data_node_1/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data/distributed/Data_node_1/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/breast_data/distributed/Data_node_2/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data/distributed/Data_node_2/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/breast_data/distributed/Data_node_3/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data/distributed/Data_node_3/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/breast_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/breast_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/breast_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/breast_data_with_weights_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data_with_weights_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/breast_data_with_weights_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data_with_weights_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/breast_data_with_weights_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/breast_data_with_weights_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/lung_data_grouped_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/lung_data_grouped_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/lung_data_grouped_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/lung_data_grouped_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/lung_data_grouped_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/lung_data_grouped_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/lung_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/lung_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/lung_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/lung_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/lung_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/lung_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_data/distributed/Coord_node/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data/distributed/Coord_node/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/random_data/distributed/Coord_node/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data/distributed/Coord_node/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/random_data/distributed/Data_node_1/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data/distributed/Data_node_1/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_data/distributed/Data_node_2/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data/distributed/Data_node_2/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_data/distributed/Data_node_3/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data/distributed/Data_node_3/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/random_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/random_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_grouped_data/distributed/Coord_node/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data/distributed/Coord_node/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/random_grouped_data/distributed/Coord_node/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data/distributed/Coord_node/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/random_grouped_data/distributed/Data_grouped_node_1/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data/distributed/Data_grouped_node_1/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_grouped_data/distributed/Data_grouped_node_2/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data/distributed/Data_grouped_node_2/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_grouped_data/distributed/Data_grouped_node_3/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data/distributed/Data_grouped_node_3/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_grouped_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/random_grouped_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/random_grouped_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/examples/random_grouped_data_with_weights_same_folder/distributed/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data_with_weights_same_folder/distributed/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/examples/random_grouped_data_with_weights_same_folder/distributed/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data_with_weights_same_folder/distributed/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/examples/random_grouped_data_with_weights_same_folder/distributed/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/examples/random_grouped_data_with_weights_same_folder/distributed/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 

--- a/cox_regression/Cox_model/generic_code/Coord_node_add_iter_cox-reg.R
+++ b/cox_regression/Cox_model/generic_code/Coord_node_add_iter_cox-reg.R
@@ -159,8 +159,8 @@ coord_call_add_iter_cox_reg <- function(man_wd=-1, man_t=-1){
     output <- cbind(beta, exp(beta), exp(-beta),  exp(beta - se), exp(beta + se), sqrt(var), p_vals)
     output <- format(output, digits = 6, nsmall = 6)
     colnames(output) <- c(" coef", " exp(coef)", " exp(-coef)", " lower .95", " upper .95", " se(coef)", " Pr(>|z|)")
-    Predictor_names <- read.csv("Global_Settings.csv")[,1]
-    Robust <- read.csv("Global_Settings.csv")[1,2]
+    Predictor_names <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[,1]
+    Robust <- read.csv(file = "Global_Settings.csv", stringsAsFactors = FALSE)[1,2]
     
     rownames(output) <- Predictor_names[-(1:2)]
     

--- a/cox_regression/Cox_model/generic_code/Coord_node_init_iter_cox-reg.R
+++ b/cox_regression/Cox_model/generic_code/Coord_node_init_iter_cox-reg.R
@@ -44,12 +44,12 @@ coord_init_iter_cox_reg <- function(man_wd=-1) {
   k <- 1
   
   # Compares local settings to ensure all data nodes are 1) aligned and 2) expect the same kind of estimation
-  Settings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+  Settings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
   Pred_names <- Settings[,1]
   Robust <- Settings[1,2]
   
   for(k in 2:K){
-    OtherSettings <- read.csv(paste0("Local_Settings_", k, ".csv"))
+    OtherSettings <- read.csv(file = paste0("Local_Settings_", k, ".csv"), stringsAsFactors = FALSE)
     Same_names <- OtherSettings[,1]
     Same_Robust <- OtherSettings[1,2]
     

--- a/cox_regression/Cox_model/generic_code/Data_node_core_iter_cox-reg.R
+++ b/cox_regression/Cox_model/generic_code/Data_node_core_iter_cox-reg.R
@@ -180,9 +180,9 @@ data_iter_cox_reg <- function(man_wd, nodeid, iterationseq, robflag) {
   
   # Read data needed to compute next value of betak
   beta <-  read.csv(paste0("Beta_", t, "_output.csv"))
-  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik <- read.csv(paste0("Rik", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik <- Rik[-1, ]
-  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE)
+  Rik_comp <- read.csv(paste0("Rik_comp", k, ".csv"), header = FALSE, blank.lines.skip = FALSE, stringsAsFactors = FALSE)
   Rik_comp <- Rik_comp[-1, ]
   
   # Verifying if weights are available. 


### PR DESCRIPTION
- Added the parameter `stringsAsFactors = FALSE` to all instances of `read.csv` that read strings. This makes sure we read those as characters (type `chr`).